### PR TITLE
Add Fira Code via Google Fonts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code&display=swap');
+
 body {
   background-color: #0b0c10;
   color: #d0f0ff;

--- a/index.md
+++ b/index.md
@@ -4,6 +4,7 @@ title: Neo-log
 ---
 
 <link rel="stylesheet" href="/assets/css/style.css">
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
 
 <p><a href="/tic-tac-toe.html">Jouer au Tic Tac Toe</a></p>
 <p><a href="/runner.html">Jouer au Runner</a></p>

--- a/runner.html
+++ b/runner.html
@@ -7,6 +7,7 @@ title: "Runner Game"
 <head>
 <meta charset="UTF-8">
 <title>Runner Game</title>
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
 <style>
   html, body { margin:0; height:100%; }
   body {

--- a/tic-tac-toe.html
+++ b/tic-tac-toe.html
@@ -7,6 +7,7 @@ title: "Tic Tac Toe"
 <head>
 <meta charset="UTF-8">
 <title>Tic Tac Toe</title>
+<link href="https://fonts.googleapis.com/css2?family=Fira+Code&display=swap" rel="stylesheet">
 <style>
 html, body {
   height: 100%;


### PR DESCRIPTION
## Summary
- import Fira Code from Google Fonts in custom stylesheet
- include Fira Code link on the homepage
- include Fira Code link on game pages

## Testing
- `python3 -m py_compile blog.py`


------
https://chatgpt.com/codex/tasks/task_e_68734e618bb48333ad8a37d30e862065