### PR TITLE
Add .gitignore with Jekyll patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Jekyll build and cache directories
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+# Log files
+*.log
+
+# OS files
+.DS_Store
+
+# Dependencies
+.bundle/
+node_modules/
+vendor/


### PR DESCRIPTION
## Summary
- include Jekyll output directories and common OS files in .gitignore

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68734e5d45ac8333ac45c6b5820bbcd7